### PR TITLE
Synchronized with get-pulsar.xml in another repository

### DIFF
--- a/script/get-pulsar.xml
+++ b/script/get-pulsar.xml
@@ -139,7 +139,7 @@
                 <include name="**/servlet-api-*.jar"/>
                 <include name="**/geronimo-javamail_1.4_spec-*.jar"/>
                 <include name="**/org.apache.felix.gogo.*.jar"/>
-                <include name="**/org.apache.servicemix.specs.jsr339-api-*.jar"/>
+                <include name="**/org.apache.servicemix.specs.jsr339-api*.jar"/>
             </patternset>
             <flattenmapper/>
         </unzip>


### PR DESCRIPTION
Hej @DSE-FredrikEngberg , jag tänkte att jag skulle testa lite med pulsar-by-example i helgen. Jag fick det dock inte att fungera. Fick detta fel:

```
C:\leb\pulsar-by-example\script\get-pulsar.xml:95: java.lang.ArrayIndexOutOfBoundsException: 1
    at org.apache.tools.zip.ZipEntry.getMergedFields(ZipEntry.java:364)
    at org.apache.tools.zip.ZipEntry.getAllExtraFieldsNoCopy(ZipEntry.java:387)
    at org.apache.tools.zip.ZipEntry.getAllExtraFields(ZipEntry.java:374)
    at org.apache.tools.zip.ZipEntry.getExtraFields(ZipEntry.java:333)
    at org.apache.tools.zip.ZipEntry.setExtra(ZipEntry.java:534)
    at org.apache.tools.zip.ZipEntry.setExtraFields(ZipEntry.java:313)
    at org.apache.tools.zip.ZipEntry.mergeExtraFields(ZipEntry.java:709)
    at org.apache.tools.zip.ZipEntry.setCentralDirectoryExtra(ZipEntry.java:545)
    at org.apache.tools.zip.ZipFile.readCentralDirectoryEntry(ZipFile.java:546)
    at org.apache.tools.zip.ZipFile.populateFromCentralDirectory(ZipFile.java:463)
    at org.apache.tools.zip.ZipFile.<init>(ZipFile.java:214)
    at org.apache.tools.ant.taskdefs.Expand.expandFile(Expand.java:184)
    at org.apache.tools.ant.taskdefs.Expand.execute(Expand.java:159)
    at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:293)
    at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
    at org.apache.tools.ant.Task.perform(Task.java:348)
    at org.apache.tools.ant.Target.execute(Target.java:435)
    at org.apache.tools.ant.Target.performTasks(Target.java:456)
    at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1405)
    at org.apache.tools.ant.helper.SingleCheckExecutor.executeTargets(SingleCheckExecutor.java:38)
    at org.apache.tools.ant.Project.executeTargets(Project.java:1260)
    at org.apache.tools.ant.taskdefs.Ant.execute(Ant.java:441)
    at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:293)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
    at org.apache.tools.ant.Task.perform(Task.java:348)
    at org.apache.tools.ant.Target.execute(Target.java:435)
    at org.apache.tools.ant.Target.performTasks(Target.java:456)
    at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1405)
    at org.apache.tools.ant.Project.executeTarget(Project.java:1376)
    at org.apache.tools.ant.helper.DefaultExecutor.executeTargets(DefaultExecutor.java:41)
    at org.apache.tools.ant.Project.executeTargets(Project.java:1260)
    at org.apache.tools.ant.Main.runBuild(Main.java:853)
    at org.apache.tools.ant.Main.startAnt(Main.java:235)
    at org.apache.tools.ant.launch.Launcher.run(Launcher.java:285)
    at org.apache.tools.ant.launch.Launcher.main(Launcher.java:112)
```

Jag diffade då med motsvarande fil i LEB-System och i LEB-Portal, lade över denna ändring och nu verkar det fungera. Vet ej om det är något att ta in eller om det egentligen är något annat som behöver fixas. När jag diffade `get-pulsar.xml` i de olika repona såg jag att det vara ganska stora skillnader i den som används i LEB-Portal, borde inte den här filen vara identisk i alla projekt där man använder pulsar?

/Erik

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dse-ab/pulsar-by-example/1)

<!-- Reviewable:end -->
